### PR TITLE
Add is-workspace input to Release Bot and release workflow

### DIFF
--- a/.github/actions/releasebot/action.yml
+++ b/.github/actions/releasebot/action.yml
@@ -25,6 +25,10 @@ inputs:
       URL of a Discord webhook for release notifications.
       To create one, follow the same steps as for the mergebot webhook.
     required: true
+  is-workspace:
+    description: Whether the repository is a monorepo workspace (e.g., using pnpm workspaces).
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -33,7 +37,7 @@ runs:
     # so we don't need to set it up again.
     - name: Install Extra Dependencies
       shell: bash
-      run: pnpm add -D -w tinyglobby
+      run: pnpm add -D ${{ inputs.is-workspace == 'true' && '-w' || '' }} tinyglobby
 
     - name: Generate BaseURL
       id: base-url

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,4 +111,4 @@ jobs:
           PublishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASE }}
           RoleMentionId: ${{ inputs.RoleMentionId }}
-          is-workspace: ${{ inputs.is-workspace }}
+          is-workspace: "${{ inputs.is-workspace }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ on:
         type: "string"
         description: "The Discord Role ID to mention in the release notification (optional)"
         required: false
+      is-workspace:
+        type: "boolean"
+        description: "Whether the repository is a monorepo workspace (e.g., using pnpm workspaces)"
+        required: false
+        default: true
 
 jobs:
   run:
@@ -106,3 +111,4 @@ jobs:
           PublishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_RELEASE }}
           RoleMentionId: ${{ inputs.RoleMentionId }}
+          is-workspace: ${{ inputs.is-workspace }}


### PR DESCRIPTION
This pull request updates the release workflow and related GitHub Action to add support for repositories that are not monorepo workspaces (i.e., those not using pnpm workspaces). It introduces a new `is-workspace` input that allows configuring this behavior, ensuring the release process works correctly for both monorepo and non-monorepo setups.

**Release workflow and action configuration improvements:**

* Added a new `is-workspace` input to both the `.github/workflows/release.yml` workflow and the `.github/actions/releasebot/action.yml` action, allowing the workflow to be used with or without pnpm workspaces. (`[[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R34-R38)`, `[[2]](diffhunk://#diff-4e76e50e8352c2c0c159f0de8cbffb6563f41d3d85e2be58005523f1e72c652aR28-R31)`)
* Updated the install dependencies step in the release bot action to conditionally use the `-w` (workspace) flag with pnpm based on the `is-workspace` input. (`[.github/actions/releasebot/action.ymlL36-R40](diffhunk://#diff-4e76e50e8352c2c0c159f0de8cbffb6563f41d3d85e2be58005523f1e72c652aL36-R40)`)
* Passed the new `is-workspace` input through the workflow to the action, ensuring the configuration is respected during execution. (`[.github/workflows/release.ymlR114](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R114)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation with flexible workspace configuration support. The release workflow now includes a new configurable option that allows the process to dynamically adapt to different project structures and environments. This improvement enables seamless releases in both workspace-enabled and standard configurations, reducing setup complexity and improving overall automation compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->