### PR TITLE
Pin npm version to v11

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -12,13 +12,13 @@ runs:
     - name: Setup Node.js based on .node-version
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version-file: '.node-version'
-        registry-url: 'https://registry.npmjs.org'
-        cache: 'pnpm'
+        node-version-file: ".node-version"
+        registry-url: "https://registry.npmjs.org"
+        cache: "pnpm"
 
     # Ensure npm 11.5.1 or later is installed
     - name: Update npm
-      run: npm install -g npm@latest
+      run: npm install -g npm@11
       shell: bash
 
     - name: Install Dependencies


### PR DESCRIPTION
This pull request makes minor updates to the `.github/actions/install/action.yml` workflow. The main change is updating the npm version installed during the workflow to ensure npm 11 is used instead of always installing the latest version.

- Workflow improvements:
  * Updated the npm installation command to specifically install npm version 11 (`npm@11`) instead of the latest version, ensuring compatibility and consistency in builds.
  * Changed YAML string delimiters from single to double quotes for consistency in the `setup-node` step.

Fixes https://github.com/nodejs/node/issues/62425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and build automation to use the project’s specified Node.js version.
  * Standardized the npm version used in automated workflows, improving consistency and reliability across environments.
  * No changes were made to application functionality or dependency installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->